### PR TITLE
docs: gpt revamp

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,16 +1,26 @@
-# Documentation Index
+# Documentation
 
-Use this folder to navigate the SettleMint BTP Universal Terraform documentation. Begin with the core articles, then drill into provider specifics or dependency details as needed.
+**BTP Universal Terraform deploys the BTP Helm release on Kubernetes with managed, in-cluster, or bring-your-own dependencies.**
 
-- **Overview** – `docs/overview.md` explains what the stack delivers and how the dependency contract works.
-- **Architecture** – `docs/architecture.md` shows how cloud scaffolding, dependencies, and the Helm release connect.
-- **Concepts** – `docs/concepts.md` documents the dependency modes and normalized outputs.
-- **Getting Started** – `docs/getting-started.md` walks through prerequisites, workflows, and example tfvars.
-- **Configuration** – `docs/configuration.md` (new) highlights the root variables you actually need to set.
-- **Providers** – `docs/providers/*.md` covers provider expectations; only AWS ships managed mode today.
-- **Dependencies** – `docs/dependencies.md` maps which modes exist per dependency and their outputs.
-- **Operations** – `docs/operations.md` records day-2 tasks like exporting kubeconfig and rotating secrets.
-- **Troubleshooting** – `docs/troubleshooting.md` lists the issues we have actually seen and how to fix them.
-- **Security** – `docs/security.md` summarizes the controls implemented in Terraform today so expectations stay grounded.
+## Quick navigation
 
-Keep new content short, reference the Terraform modules directly, and update `examples/*.tfvars` and docs together whenever inputs or outputs change.
+**Start here**
+- [Getting Started](getting-started.md) – Install and verify the stack
+- [Configuration](configuration.md) – Set required inputs for your environment
+
+**Core concepts**
+- [Overview](overview.md) – What the stack delivers
+- [Architecture](architecture.md) – How components connect
+- [Concepts](concepts.md) – Dependency modes and normalized outputs
+- [Dependencies](dependencies.md) – Available modes per dependency
+
+**Provider-specific**
+- [AWS](providers/aws.md) – Managed services (RDS, ElastiCache, S3, Cognito)
+- [Azure](providers/azure.md) – Placeholder for future managed support
+- [GCP](providers/gcp.md) – Placeholder for future managed support
+- [Generic](providers/generic.md) – Local/on-prem Kubernetes clusters
+
+**Operations**
+- [Operations](operations.md) – Verify deployments, rotate credentials, clean up
+- [Security](security.md) – TLS, encryption, IAM, and secrets handling
+- [Troubleshooting](troubleshooting.md) – Common issues and solutions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,26 +1,26 @@
 # Architecture
 
-The Terraform stack orchestrates cloud scaffolding, dependency modules, and the BTP Helm release through a normalized contract. This page highlights the moving parts and how traffic flows between them.
+**The stack orchestrates cloud scaffolding, dependency modules, and the BTP Helm release through a normalized contract.**
 
-## Whole picture
+## Components and data flow
 
 ```mermaid
 %%{init: {'theme':'neutral','securityLevel':'loose','flowchart':{'htmlLabels':true,'curve':'basis'}}}%%
 flowchart LR
   subgraph Cloud
     direction TB
-    net["Networking + IAM helpers"]
+    net["Networking + IAM"]
     pg["Postgres"]
     redis["Redis"]
     obj["Object Storage"]
-    oauth["OAuth / Identity"]
-    secrets["Secrets backend"]
-    metrics["Metrics and Logs"]
+    oauth["OAuth"]
+    secrets["Secrets"]
+    metrics["Metrics/Logs"]
   end
 
   subgraph Kubernetes
-    ingress["Ingress and TLS"]
-    deps["Helm dependencies (k8s mode)"]
+    ingress["Ingress + TLS"]
+    deps["Helm dependencies"]
     btp["BTP Helm Release"]
   end
 
@@ -36,19 +36,48 @@ flowchart LR
   net --> deps
 ```
 
-Managed dependency provisioning is implemented for AWS today via the `cloud/aws` module and AWS-specific modes within each dependency. Azure and GCP mode files are placeholders that let you wire existing services until native support ships.
-
 ## Dependency groups
-- **Data plane** – Postgres and Redis provide persistence. AWS managed paths (RDS, ElastiCache) are available, while Azure and GCP currently rely on either Kubernetes charts or bring-your-own connection details.
-- **Storage & identity** – Object storage, OAuth, and secrets modules support AWS managed services (S3, Cognito, Secrets Manager) alongside Kubernetes charts such as MinIO, Keycloak, and Vault. Other clouds fall back to BYO until their modules are implemented.
-- **Edge & observability** – `ingress_tls` installs ingress-nginx and cert-manager in Kubernetes. Metrics/logs are provided via kube-prometheus-stack and Loki today; managed observability integrations are still pending.
 
-## Networking & IAM
-- `cloud/aws` prepares foundational AWS resources: VPC networking, security groups, IAM roles, and Route53 context consumed by dependencies.
-- When running in k8s mode, Terraform ensures namespaces and service accounts exist before Helm releases are applied.
-- Managed modes use least-privilege IAM policies tied to the AWS resources they create (e.g., S3 bucket policies, RDS parameter groups). Similar scaffolding for other providers will follow.
+**Data plane** – Postgres and Redis
+- AWS: RDS and ElastiCache
+- Kubernetes: Zalando Postgres Operator and Bitnami Redis
+- Bring-your-own: Your existing endpoints
+
+**Storage and identity** – Object Storage, OAuth, Secrets
+- AWS: S3, Cognito, Secrets Manager (planned)
+- Kubernetes: MinIO, Keycloak, Vault
+- Bring-your-own: Your existing services
+
+**Edge and observability** – Ingress, TLS, Metrics, Logs
+- Kubernetes: ingress-nginx, cert-manager, kube-prometheus-stack, Loki
+- Managed observability integrations are planned
+
+## Networking and IAM
+
+**AWS scaffolding** (`cloud/aws`)
+- VPC networking, subnets, security groups
+- IAM roles and policies
+- Route53 context
+- Consumed by dependency modules
+
+**Kubernetes scaffolding**
+- Namespaces created when `manage_namespace = true`
+- Service accounts for Helm releases
+
+**Managed modes** use least-privilege IAM policies tied to specific resources.
 
 ## Security posture
-- TLS termination happens at the ingress layer with cert-manager issuing certificates (DNS-01 through Route53 when AWS credentials are provided, otherwise HTTP-01).
-- Secrets remain in their authoritative stores: AWS Secrets Manager or Vault-backed Kubernetes secrets depending on mode.
-- Rotate credentials in the source system (Secrets Manager, Vault, BYO endpoint) and re-run `terraform apply` so Helm releases pick up the changes.
+
+**TLS termination** at ingress layer
+- cert-manager issues certificates
+- DNS-01 via Route53 (when AWS credentials provided)
+- HTTP-01 otherwise
+
+**Secrets** remain in authoritative stores
+- AWS Secrets Manager
+- Vault-backed Kubernetes secrets
+- Bring-your-own secret backend
+
+**Credential rotation**
+- Rotate in source system (Secrets Manager, Vault, bring-your-own)
+- Run `terraform apply` to propagate changes to Helm releases

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,36 +1,85 @@
-# Configuration Guide
+# Configuration
 
-This page highlights the Terraform inputs you normally touch when preparing an environment. Use the example tfvars files in `examples/` as a starting point and only override what differs for your workspace.
+**Start with an example tfvars file from `examples/` and customize only what you need.**
 
-## Core inputs
-- `platform` (see `variables.tf`): pick `aws`, `azure`, `gcp`, or `generic`. Today only the AWS path provisions managed infrastructure; the others assume Kubernetes or bring-your-own endpoints.
-- `base_domain`: hostname suffix for ingress. Local clusters often use `127.0.0.1.nip.io`; cloud profiles point to a routed domain.
-- `namespaces`: optional overrides when you want each dependency deployed into a dedicated namespace instead of the default `btp-deps`.
+## Required inputs
 
-## Infrastructure orchestration
-- `vpc`: wiring for the AWS cloud scaffolding (`cloud/aws`). Leave it empty for local Kubernetes; populate the `aws` object when `platform = "aws"` so subnets and security groups exist for managed dependencies. Set `create_vpc = false` and supply existing IDs when reusing networking.
-- `k8s_cluster`: controls the `deps/k8s_cluster` module. Supported modes are `aws` (EKS), `byo` (existing kubeconfig), or `disabled`. Azure and GCP blocks are placeholders; keep the mode on `byo` if you already operate the cluster.
-- The cluster module outputs a rendered kubeconfig (`outputs.tf:82`). Export it to verify workloads whenever Terraform created the control plane.
+**Platform**
+- `platform` – Set to `aws`, `azure`, `gcp`, or `generic`
+- AWS provisions managed infrastructure; other platforms use Kubernetes or bring-your-own
+
+**Domain**
+- `base_domain` – Hostname suffix for ingress
+  - Local: `127.0.0.1.nip.io`
+  - Cloud: your routed domain
+
+**Namespaces** (optional)
+- `namespaces` – Override to deploy each dependency in a dedicated namespace
+- Default: all in `btp-deps`
+
+## AWS infrastructure
+
+**VPC**
+- `vpc.aws` – Required when `platform = "aws"`
+- Set `create_vpc = false` to use existing networking
+- Leave empty for local Kubernetes
+
+**Kubernetes cluster**
+- `k8s_cluster.mode` – Choose `aws` (EKS), `byo` (existing kubeconfig), or `disabled`
+- Terraform outputs kubeconfig at `outputs.tf:82` when it creates the cluster
 
 ## Dependency modes
-- Every dependency block in `variables.tf` accepts a `mode` plus provider-specific configuration. Defaults are `k8s` for everything except DNS (`byo`) and OAuth (`disabled`).
-- Managed implementations ship for AWS across Postgres, Redis, Object Storage, and OAuth. Kubernetes mode deploys Helm charts (Zalando Postgres operator, Bitnami Redis, MinIO, Keycloak, Vault, kube-prometheus-stack, ingress-nginx + cert-manager).
-- BYO mode expects you to provide connection details and credentials. Use it for Azure/GCP today or when another team operates the service.
-- When you flip a dependency to AWS managed, make sure `vpc.aws` is populated so subnet groups and security groups resolve. Terraform reuses values passed in `examples/aws-config.tfvars`.
+
+**Each dependency accepts a mode**
+- `aws` – Managed services (RDS, ElastiCache, S3, Cognito)
+- `k8s` – Helm charts (Zalando Postgres, Bitnami Redis, MinIO, Keycloak, Vault)
+- `byo` – Your existing endpoints and credentials
+
+**Defaults**
+- Most dependencies: `k8s`
+- DNS: `byo`
+- OAuth: `disabled`
+
+**For AWS managed mode**, populate `vpc.aws` so subnet groups and security groups resolve.
 
 ## DNS and ingress
-- `dns`: defaults to `mode = "byo"` which only returns helper outputs. Set `mode = "aws"` and provide a Route53 zone to let Terraform create records that match the ingress module outputs.
-- `ingress_tls`: manages ingress-nginx and cert-manager. Provide `acme_email` and, for AWS DNS automation, a `route53_credentials_secret_name` plus AWS credentials injected via environment variables (see the AWS access key inputs in `variables.tf`).
-- Wildcard certificates are derived automatically when the DNS module knows the base domain (`main.tf:45`). Override `default_certificate` in the ingress module if you need a different secret name.
+
+**DNS**
+- Default: `mode = "byo"` (returns helper outputs only)
+- AWS: Set `mode = "aws"` and provide Route53 zone ID
+
+**Ingress and TLS**
+- `ingress_tls` installs ingress-nginx and cert-manager
+- Provide `acme_email` for Let's Encrypt
+- For AWS DNS-01 automation, set `route53_credentials_secret_name` and export:
+  - `TF_VAR_aws_access_key_id`
+  - `TF_VAR_aws_secret_access_key`
+
+**Wildcard certificates** are generated automatically when DNS mode knows the base domain (main.tf:45).
 
 ## Secrets and credentials
-- Sensitive values are defined under “Credentials and secret inputs” in `variables.tf`. Supply them with `TF_VAR_*` environment variables before running Terraform; do not place them in tfvars.
-- Vault (k8s mode) defaults to dev mode for quick trials. Pass `secrets.k8s.dev_mode = false` in a tfvars file before using it beyond experimentation, and wire an external storage backend via `secrets.k8s.values`.
-- AWS Route53 DNS automation needs `TF_VAR_aws_access_key_id` and `TF_VAR_aws_secret_access_key` unless you rely on the instance/role profile. Those credentials are only written into a Kubernetes secret in the ingress namespace.
 
-## Picking an example
-- `examples/k8s-config.tfvars`: all dependencies in k8s mode for local clusters (OrbStack, kind, minikube).
-- `examples/aws-config.tfvars`: AWS managed services plus ingress TLS via Route53. Update subnet IDs, Route53 zone, and callback URLs before applying.
-- `examples/mixed-config.tfvars`: demonstrates mixing AWS managed Postgres/Redis with in-cluster dependencies.
-- `examples/azure-config.tfvars` and `examples/gcp-config.tfvars`: show how to supply BYO endpoints for those clouds today.
-- `examples/byo-config.tfvars`: fully external dependencies for teams layering Terraform on top of existing services.
+**Supply sensitive values via environment variables**
+```bash
+export TF_VAR_grafana_admin_password=...
+export TF_VAR_aws_access_key_id=...
+export TF_VAR_aws_secret_access_key=...
+```
+
+Never put secrets in tfvars files.
+
+**Vault in k8s mode**
+- Defaults to dev mode for testing
+- Set `secrets.k8s.dev_mode = false` for production
+- Configure storage via `secrets.k8s.values`
+
+## Example files
+
+| File | Use case |
+|------|----------|
+| `k8s-config.tfvars` | Local clusters (OrbStack, kind, minikube) |
+| `aws-config.tfvars` | AWS managed services |
+| `mixed-config.tfvars` | Mix AWS managed + in-cluster |
+| `azure-config.tfvars` | Azure bring-your-own endpoints |
+| `gcp-config.tfvars` | GCP bring-your-own endpoints |
+| `byo-config.tfvars` | External dependencies |

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,16 +1,25 @@
 # Overview
 
-BTP Universal Terraform provides a single Terraform stack that deploys the BTP Helm release on Kubernetes while wiring required dependencies (Postgres, Redis, Object Storage, OAuth, Secrets, Ingress/TLS, Metrics/Logs) from any supported provider mode: managed, in-cluster, or bring-your-own.
+**BTP Universal Terraform deploys the BTP Helm release on Kubernetes with all required dependencies.**
 
-## Why it matters
-- Settlemint-validated Terraform stack that covers AWS managed services today and Kubernetes-first installs everywhere.
-- Flexible installs: toggle dependencies between AWS managed, in-cluster Helm charts, or bring-your-own endpoints without touching BTP values.
-- Clear contracts and examples so teams can add other clouds (Azure, GCP) while native modules are completed.
+## Dependencies can run in three modes
 
-## Start here
-- Run the stack: [docs/getting-started.md](getting-started.md)
-- Understand the contract: [docs/concepts.md](concepts.md)
-- Review provider specifics: [docs/providers/aws.md](providers/aws.md), [docs/providers/azure.md](providers/azure.md), [docs/providers/gcp.md](providers/gcp.md), [docs/providers/generic.md](providers/generic.md)
+Each dependency (Postgres, Redis, Object Storage, OAuth, Secrets, Ingress/TLS, Metrics/Logs) supports:
+- **Managed** – Cloud provider services (RDS, ElastiCache, S3, Cognito on AWS)
+- **Kubernetes** – In-cluster Helm charts (Zalando Postgres, Bitnami Redis, MinIO, Keycloak)
+- **Bring-your-own** – External endpoints you provide
+
+**Mix modes freely.** Use AWS RDS for Postgres and in-cluster Redis in the same deployment.
+
+## AWS has complete managed support today
+
+AWS managed modes are fully implemented. Azure and GCP use bring-your-own mode until native support ships.
+
+## Next steps
+
+- [Getting Started](getting-started.md) – Install and verify
+- [Concepts](concepts.md) – How dependency modes work
+- [AWS Provider](providers/aws.md) – AWS-specific details
 
 ```mermaid
 %%{init: {'theme':'neutral','securityLevel':'loose','flowchart':{'htmlLabels':true,'curve':'basis'}}}%%

--- a/docs/providers/aws.md
+++ b/docs/providers/aws.md
@@ -1,83 +1,69 @@
-# AWS Provider Guide
+# AWS Provider
 
-## Scope
-- `cloud/aws` scaffolding module provisions VPC networking, subnets, security groups, and IAM roles consumed by dependency modules.
-- Managed dependency modes ship for RDS (Postgres), ElastiCache (Redis), S3 (object storage), and Cognito (OAuth). Other dependencies (secrets, ingress, metrics/logs) currently run via Kubernetes or bring-your-own endpoints.
+**AWS has complete managed support for Postgres, Redis, Object Storage, and OAuth.**
+
+## Managed services available
+
+The `cloud/aws` module provisions:
+- **Networking** – VPC, subnets, security groups, IAM roles
+- **Postgres** – RDS with Multi-AZ, encryption, automated backups
+- **Redis** – ElastiCache replication group with TLS
+- **Object Storage** – S3 buckets with versioning and encryption
+- **OAuth** – Cognito user pools and app clients
+
+**Other dependencies** (ingress, secrets, metrics/logs) run in Kubernetes mode.
 
 ## Prerequisites
-- IAM user or role with permissions for VPC, EC2, IAM, RDS, ElastiCache, S3, Cognito, and Route53 resources.
-- Route53 hosted zone if you plan to terminate ingress with a custom domain.
-- Remote state backend (S3 + DynamoDB) recommended for shared environments.
 
-## Managed mode notes
-- RDS: defaults to Multi-AZ with automated backups; provide subnet group IDs in the `config` block to reuse existing networking.
-- ElastiCache: deploys a replication group with TLS if the subnet group supports it.
-- Cognito: creates a user pool and app client; use `callback_urls` to align with your BTP hostname.
-- Object storage: S3 buckets can be auto-generated with versioning and encryption defaults or you can point to an existing bucket.
-- Ingress/TLS: the `ingress_tls` module installs ingress-nginx + cert-manager; provide AWS credentials and a Route53 zone ID to enable DNS-01 automation.
+**IAM permissions for**
+- VPC, EC2, IAM
+- RDS, ElastiCache, S3
+- Cognito, Route53
 
-## Architecture (example: `examples/aws-config.tfvars`)
+**Optional**
+- Route53 hosted zone for custom domains
+- S3 + DynamoDB for remote state backend
 
-```mermaid
-%%{init: {'theme':'neutral','securityLevel':'loose','flowchart':{'htmlLabels':true,'curve':'basis'}}}%%
-flowchart LR
-  subgraph AWS["AWS Account"]
-    subgraph VPC["VPC 10.0.0.0/16"]
-      direction TB
-      subgraph Managed["Managed dependencies"]
-        direction TB
-        rds["RDS Postgres (btp-postgres)"]
-        redis["ElastiCache Redis (btp-redis)"]
-        s3["S3 Bucket (artifacts)"]
-        cognito["Cognito User Pool + Client"]
-        secrets["Secrets Manager (credential store)"]
-      end
-      subgraph Cluster["Ingress + EKS"]
-        direction LR
-        alb["AWS Load Balancer (ingress)"]
-        subgraph EKS["EKS Cluster (btp-eks)"]
-          subgraph DepsNS["Namespace btp-deps"]
-            ingress["ingress-nginx + cert-manager"]
-            deps["Helm dependencies (k8s mode)"]
-            metrics["kube-prometheus-stack + Loki"]
-          end
-          subgraph AppNS["Namespace platform"]
-            btp["BTP Helm Release"]
-          end
-        end
-      end
-    end
-    route53["Route53 Hosted Zone"]
-  end
+## Service defaults
 
-  rds --> redis
-  redis --> s3
-  s3 --> cognito
-  cognito --> secrets
+**RDS Postgres**
+- Multi-AZ with deletion protection
+- gp3 100 GiB storage (auto-scales to 200 GiB)
+- Daily backups (14 day retention)
+- Performance Insights enabled
+- Final snapshot on destroy
 
-  ingress --> btp
-  deps --> btp
-  btp --> rds
-  btp --> redis
-  btp --> s3
-  btp --> cognito
-  btp --> secrets
-  btp --> metrics
-  route53 --> alb
-  alb --> ingress
+Override in the dependency `config` block for dev environments.
 
-  linkStyle 0 stroke-width:0,fill:none,stroke:transparent
-  linkStyle 1 stroke-width:0,fill:none,stroke:transparent
-  linkStyle 2 stroke-width:0,fill:none,stroke:transparent
-  linkStyle 3 stroke-width:0,fill:none,stroke:transparent
-```
+**ElastiCache Redis**
+- Replication group with TLS
+- Transit encryption enabled when subnet group supports it
 
-> **Note:** The `secrets` module still uses Vault (k8s) or BYO in the current implementation; the diagram highlights the intended Secrets Manager integration referenced in the example profile.
+**Cognito OAuth**
+- User pool and app client created
+- Set `callback_urls` to match your BTP hostname
 
-## Kubernetes mode integration
-- Helm deployments (e.g., Zalando Postgres, Bitnami Redis) run inside your cluster; ensure the cluster has enough capacity and storage classes that support ReadWriteOnce.
-- Security groups created by `cloud/aws` can be reused by AWS Load Balancer Controller if you adopt it for ingress.
+**S3 Object Storage**
+- Versioning enabled
+- Server-side encryption (SSE-S3)
+- Public access blocked
+- Can use existing bucket
 
-## Bring-your-own tips
-- Supply existing endpoints via the dependency `config.endpoint` blocks; include TLS certificates or CA bundles for verification.
-- Store credentials in AWS Secrets Manager and reference ARNs to avoid committing passwords in tfvars.
+**Ingress and TLS**
+- ingress-nginx + cert-manager installed in Kubernetes
+- Provide AWS credentials and Route53 zone ID for DNS-01 automation
+
+## Using Kubernetes mode with AWS
+
+**Helm charts run inside your EKS cluster**
+- Ensure sufficient capacity and storage classes supporting ReadWriteOnce
+- Security groups from `cloud/aws` can be reused by AWS Load Balancer Controller
+
+**For ingress**, security groups allow traffic from the VPC CIDR and any additional groups you configure.
+
+## Bring-your-own endpoints
+
+**Supply existing AWS resources**
+- Provide endpoints via dependency `config.endpoint` blocks
+- Include TLS certificates or CA bundles for verification
+- Store credentials in AWS Secrets Manager and reference ARNs (avoid committing passwords)

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,13 +1,31 @@
-# Azure Provider Guide
+# Azure Provider
 
-## Status
-Native Azure modules are not implemented yet. The Azure mode files under each dependency are placeholders so you can describe connection details, but Terraform does not currently provision Azure resources.
+**Native Azure modules are not implemented yet. Use bring-your-own mode to connect existing Azure services.**
+
+## Azure support is planned
+
+When implemented, the `cloud/azure` module will provision:
+- Virtual networks and managed identities
+- Azure Database for PostgreSQL Flexible Server
+- Azure Cache for Redis
+- Blob Storage
+- Entra ID (Azure AD)
+- Key Vault
 
 ## Working with Azure today
-- Use `mode = "byo"` to connect to existing Azure services (Flexible Server, Cache for Redis, Blob Storage, Entra ID, Key Vault, etc.) and supply endpoints/credentials via tfvars.
-- Keep ingress, metrics/logs, and secrets in `k8s` mode (ingress-nginx, kube-prometheus-stack, Vault) until Azure-specific integrations land.
-- Manage Azure networking, identities, and DNS outside of this repository; feed the resulting values into the root module inputs.
 
-## Roadmap considerations
-- When adding Azure support, align with managed identities and private networking expectations in `cloud/azure`.
-- Document any required roles or Azure CLI steps in this guide so teams can follow a consistent pattern.
+**Use `mode = "byo"` for all dependencies**
+- Provide endpoints and credentials in tfvars
+- Keep ingress, metrics/logs, and secrets in `k8s` mode
+
+**Manage outside Terraform**
+- Networking, identities, DNS
+- All Azure resources
+- Feed resulting values into root module inputs
+
+## Roadmap
+
+When adding Azure support:
+- Align with managed identities and private networking
+- Document required roles and Azure CLI steps
+- Follow consistent patterns with AWS implementation

--- a/docs/providers/gcp.md
+++ b/docs/providers/gcp.md
@@ -1,13 +1,32 @@
-# GCP Provider Guide
+# GCP Provider
 
-## Status
-Native GCP modules are not implemented yet. The GCP mode files inside each dependency act as placeholders so you can describe existing resources, but Terraform does not provision Google Cloud services today.
+**Native GCP modules are not implemented yet. Use bring-your-own mode to connect existing Google Cloud services.**
+
+## GCP support is planned
+
+When implemented, the `cloud/gcp` module will provision:
+- VPC networks and service accounts
+- Cloud SQL
+- Memorystore for Redis
+- Cloud Storage (GCS)
+- Identity Platform
+- Secret Manager
 
 ## Working with GCP today
-- Use `mode = "byo"` to connect to Cloud SQL, Memorystore, GCS, Identity Platform, Secret Manager, or other existing services; provide endpoints and credentials via tfvars.
-- Keep ingress, metrics/logs, and secrets in `k8s` mode (ingress-nginx, kube-prometheus-stack, Vault) until dedicated GCP integrations are added.
-- Manage networking, service accounts, and DNS externally and feed the resulting values into root module inputs.
 
-## Roadmap considerations
-- When implementing GCP support, plan for Workload Identity, private service connectivity, and certificate automation so Kubernetes resources stay decoupled from service account keys.
-- Document the required IAM roles and API enablement steps here once the modules land.
+**Use `mode = "byo"` for all dependencies**
+- Provide endpoints and credentials in tfvars
+- Keep ingress, metrics/logs, and secrets in `k8s` mode
+
+**Manage outside Terraform**
+- Networking, service accounts, DNS
+- All GCP resources
+- Feed resulting values into root module inputs
+
+## Roadmap
+
+When adding GCP support:
+- Plan for Workload Identity and private service connectivity
+- Avoid service account keys where possible
+- Document required IAM roles and API enablement
+- Support certificate automation for Kubernetes resources

--- a/docs/providers/generic.md
+++ b/docs/providers/generic.md
@@ -1,20 +1,41 @@
-# Generic Provider Guide
+# Generic Provider
 
-## Scope
-- The generic profile targets environments where you control the Kubernetes cluster directly (local OrbStack/kind/minikube or on-prem).
-- No cloud scaffolding is provisioned; all dependencies default to Kubernetes mode unless overridden with `byo`.
+**The generic profile runs all dependencies inside Kubernetes. Use this for local development or on-premises clusters.**
+
+## Supported environments
+
+- **Local** – OrbStack, kind, minikube
+- **On-premises** – Bare metal or VM-based Kubernetes
+- **Cloud Kubernetes** – When you manage the cluster yourself
+
+No cloud scaffolding is provisioned.
 
 ## Prerequisites
-- Accessible Kubernetes cluster with sufficient compute, storage, and ingress capabilities.
-- Storage class that supports ReadWriteOnce (e.g., local-path provisioner, OrbStack’s default).
-- TLS support via cert-manager (self-signed or upstream issuer).
+
+**Kubernetes cluster with**
+- Sufficient compute and storage
+- Storage class supporting ReadWriteOnce (e.g., local-path provisioner)
+- Ingress capabilities
+
+**TLS support**
+- cert-manager with self-signed or upstream issuer
 
 ## Kubernetes mode defaults
-- Postgres via Zalando Operator with persistent volumes.
-- Redis via Bitnami chart with password auth enabled.
-- MinIO for object storage with optional console exposure.
-- Keycloak for OAuth, Vault (or Vault dev) for secrets, ingress-nginx + cert-manager for edge routing, kube-prometheus-stack + Loki for observability.
 
-## Bring-your-own tips
-- Supply existing endpoints for any dependency using the `byo` mode configuration; Kubernetes services can still mount credentials via secrets.
-- For ingress, point the BYO configuration to an external load balancer or reverse proxy and provide certificate references if TLS is terminated elsewhere.
+All dependencies run as Helm charts:
+- **Postgres** – Zalando Operator with persistent volumes
+- **Redis** – Bitnami chart with password auth
+- **Object Storage** – MinIO with optional console
+- **OAuth** – Keycloak
+- **Secrets** – Vault (or Vault dev mode)
+- **Ingress** – ingress-nginx + cert-manager
+- **Observability** – kube-prometheus-stack + Loki
+
+## Using bring-your-own endpoints
+
+**Supply existing services**
+- Set `mode = "byo"` for any dependency
+- Provide connection details in tfvars
+- Kubernetes services can still mount credentials via secrets
+
+**For ingress**, point to an external load balancer or reverse proxy if TLS terminates elsewhere.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,29 +1,97 @@
-# Security Notes
+# Security
 
-This page covers the controls currently implemented in the Terraform modules.
+**Security controls currently implemented in Terraform modules.**
 
 ## Ingress and certificates
-- `deps/ingress_tls` installs ingress-nginx and cert-manager with HTTP-01 challenges by default (`deps/ingress_tls/main.tf:63`). DNS-01 via Route53 is enabled only when you set `ingress_tls.k8s.route53_credentials_secret_name` and supply AWS credentials (see the AWS access key variables in `variables.tf`).
-- Profile tfvars pick the controller service exposure. Example: `examples/aws-config.tfvars:140` uses `LoadBalancer`, while `examples/k8s-config.tfvars` keeps the chart default. Check the `ingress_tls.k8s.values_nginx` block in your profile to confirm what gets applied.
-- Wildcard certificates are optional. Terraform provisions them when the DNS module returns wildcard hostnames (`main.tf:63`); otherwise cert-manager issues per-ingress certificates.
+
+**TLS termination** via cert-manager (deps/ingress_tls/main.tf:63)
+- HTTP-01 challenges by default
+- DNS-01 via Route53 when configured
+
+**Enable DNS-01 automation**
+- Set `ingress_tls.k8s.route53_credentials_secret_name`
+- Export `TF_VAR_aws_access_key_id` and `TF_VAR_aws_secret_access_key`
+- See AWS access key variables in variables.tf
+
+**Ingress controller service exposure**
+- Configured in tfvars (examples/aws-config.tfvars:140)
+- `LoadBalancer` for cloud deployments
+- Chart defaults for local clusters
+- Check `ingress_tls.k8s.values_nginx` in your profile
+
+**Wildcard certificates** are optional
+- Provisioned when DNS module returns wildcard hostnames (main.tf:63)
+- Otherwise cert-manager issues per-ingress certificates
 
 ## Data stores
-- RDS instances enable encryption at rest and automated backups by default (`deps/postgres/aws.tf:57`).
-- ElastiCache can run with transit and at-rest encryption (`deps/redis/aws.tf:45`). Enable `transit_encryption_enabled` and provide an authentication token to require TLS-based clients; otherwise Redis listens in plaintext inside the VPC.
-- The S3 module enables server-side encryption and blocks public access on managed buckets (`deps/object_storage/aws.tf:46`). If you reference an existing bucket, verify those settings yourself.
-- Kubernetes mode dependencies deploy Helm charts with in-cluster services and default to non-persistent storage. Add persistence and network policies through the `values` overrides when needed.
+
+**RDS Postgres** (deps/postgres/aws.tf:57)
+- Encryption at rest enabled
+- Automated backups enabled
+- Multi-AZ by default
+
+**ElastiCache Redis** (deps/redis/aws.tf:45)
+- Transit encryption available
+- At-rest encryption available
+- Enable `transit_encryption_enabled` and provide auth token for TLS clients
+- Without TLS, Redis listens in plaintext inside VPC
+
+**S3 Object Storage** (deps/object_storage/aws.tf:46)
+- Server-side encryption enabled
+- Public access blocked
+- For existing buckets, verify these settings manually
+
+**Kubernetes mode dependencies**
+- Deploy Helm charts with in-cluster services
+- Default: non-persistent storage
+- Add persistence and network policies via `values` overrides
 
 ## Secrets and credentials
-- Vault in k8s mode runs in dev mode unless you disable it (`deps/secrets/k8s.tf:19`). Switch `secrets.k8s.dev_mode = false` and wire persistent storage before using it in production.
-- Terraform never writes secrets to disk: all sensitive inputs come from the “Credentials and secret inputs” section of `variables.tf`. Keep using `TF_VAR_*` exports or a secret manager integration with Terraform Cloud.
-- OAuth managed mode (Cognito) provisions a user pool and client but leaves rotation and MFA policies to the operator. Document your requirements in `examples/aws-config.tfvars` so apply scripts stay aligned.
+
+**Vault in k8s mode** (deps/secrets/k8s.tf:19)
+- Runs in dev mode by default
+- Switch `secrets.k8s.dev_mode = false` for production
+- Configure persistent storage before production use
+
+**Terraform never writes secrets to disk**
+- All sensitive inputs from variables.tf "Credentials and secret inputs"
+- Use `TF_VAR_*` environment variables
+- Or integrate with Terraform Cloud secret manager
+
+**OAuth managed mode (Cognito)**
+- Provisions user pool and client
+- Rotation and MFA policies managed by operator
+- Document requirements in examples/aws-config.tfvars
 
 ## IAM and networking
-- The AWS cloud scaffolding restricts security groups for Postgres and Redis to traffic from the VPC CIDR and any additional groups you list (`cloud/aws/main.tf:152`). Review those rules when connecting from outside the VPC.
-- EKS roles receive the standard AWS-managed policies (`deps/k8s_cluster/aws.tf:24`). Add custom policies through IRSA if workloads need additional AWS API access; Terraform only creates the cluster-level roles.
-- Route53 credentials used for DNS-01 live in a Kubernetes secret local to the ingress namespace (`deps/ingress_tls/main.tf:173`). Rotate the AWS access keys periodically and reapply to refresh the secret.
 
-## Out of scope today
-- Azure and GCP managed services are placeholders; no Terraform resources exist yet for those clouds, but the provider mode files are ready for upcoming implementations.
-- Web application firewalls, runtime security agents, and centralized SIEM integrations are not provisioned here. Layer them on through your cloud platform or Kubernetes tooling.
-- Compliance artefacts and policy-as-code checks are outside this repository—run them separately during CI/CD.
+**AWS security groups** (cloud/aws/main.tf:152)
+- Postgres and Redis restricted to VPC CIDR
+- Additional groups can be listed in configuration
+- Review rules when connecting from outside VPC
+
+**EKS IAM roles** (deps/k8s_cluster/aws.tf:24)
+- Standard AWS-managed policies attached
+- For workload AWS API access, add custom policies via IRSA
+- Terraform creates only cluster-level roles
+
+**Route53 credentials for DNS-01** (deps/ingress_tls/main.tf:173)
+- Stored in Kubernetes secret in ingress namespace
+- Rotate AWS access keys periodically and reapply
+
+## Out of scope
+
+**Azure and GCP managed services** are placeholders
+- No Terraform resources exist yet
+- Provider mode files ready for future implementation
+
+**Additional security tooling not included**
+- Web application firewalls
+- Runtime security agents
+- Centralized SIEM integrations
+- Layer these on through cloud platform or Kubernetes tooling
+
+**Compliance artifacts**
+- Policy-as-code checks
+- Run separately during CI/CD
+- Not part of this repository

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,20 +1,88 @@
 # Troubleshooting
 
-When Terraform or the installer appears stuck, inspect the cluster and supporting services before changing configuration.
+**Common issues and solutions when Terraform or the installer appears stuck.**
 
-## Terraform run
-- Re-run `terraform plan` with `TF_LOG=INFO` to surface provider errors that may have scrolled past during the first apply.
-- Confirm required `TF_VAR_*` secrets are loaded; missing inputs often result in resources waiting on credentials (see `variables.tf`).
+## Terraform runs
+
+**Enable debug logging**
+```bash
+TF_LOG=INFO terraform plan -var-file <profile>.tfvars
+```
+
+This surfaces provider errors that may have scrolled past.
+
+**Check required environment variables**
+```bash
+env | grep TF_VAR_
+```
+
+Missing `TF_VAR_*` secrets cause resources to wait on credentials. See variables.tf for required inputs.
 
 ## Kubernetes cluster
-- Check pod status: `kubectl get pods -n btp-deps` and `kubectl describe pod/<name>`. Most install issues stem from storage classes, ingress classes, or image pull permissions not matching the cluster.
-- Validate that a compatible StorageClass exists if you enabled persistence in any dependency Helm values.
-- Inspect services that expect external endpoints (for example, `kubectl get svc -n btp-deps`). If the cluster should provision a load balancer, make sure the service type aligns with the provider and that the controller reconciles the object.
 
-## Managed cloud dependencies
-- For AWS, verify subnet and security group IDs passed to Postgres/Redis/Object Storage are correct. Terraform creates subnet groups only when `*_manage_subnet_group = true`; otherwise it requires existing names.
-- Check the AWS console for failed create/update operations—RDS and ElastiCache emit detailed events when parameter values or networking are invalid.
+**Check pod status**
+```bash
+kubectl get pods -n btp-deps
+kubectl describe pod/<pod-name> -n btp-deps
+```
+
+**Common issues**
+- **Storage classes** – Ensure compatible StorageClass exists if persistence enabled
+- **Ingress classes** – Verify ingress class matches cluster configuration
+- **Image pull permissions** – Check service accounts have registry access
+
+**Validate StorageClass** (when persistence enabled)
+```bash
+kubectl get storageclass
+```
+
+**Inspect services expecting external endpoints**
+```bash
+kubectl get svc -n btp-deps
+```
+
+For cloud clusters expecting load balancers:
+- Verify service type aligns with provider
+- Ensure controller reconciles the object
+
+## AWS managed dependencies
+
+**Verify subnet and security group IDs**
+- Check values passed to Postgres/Redis/Object Storage
+- Terraform creates subnet groups only when `*_manage_subnet_group = true`
+- Otherwise requires existing subnet group names
+
+**Check AWS console for failed operations**
+- RDS and ElastiCache emit detailed events
+- Look for parameter value errors or networking issues
+
+**Common AWS errors**
+- Invalid CIDR ranges in security groups
+- Subnet groups in wrong availability zones
+- Missing IAM permissions for resource creation
 
 ## DNS and TLS
-- If certificates do not issue, confirm Route53 credentials are present in the ingress namespace (`deps/ingress_tls/main.tf:173`) or switch to HTTP-01 challenges for local clusters.
-- Use `kubectl describe certificate` and `kubectl describe order` (cert-manager CRDs) to identify missing DNS records or solver configuration mismatches.
+
+**Certificates not issuing**
+
+**Check Route53 credentials** (for DNS-01)
+```bash
+kubectl get secret -n <ingress-namespace>
+```
+
+Credentials must be present (deps/ingress_tls/main.tf:173).
+
+**Switch to HTTP-01 for local clusters**
+- Remove Route53 configuration
+- cert-manager will use HTTP-01 challenges
+
+**Debug certificate issues**
+```bash
+kubectl describe certificate <cert-name>
+kubectl describe order <order-name>
+```
+
+Look for:
+- Missing DNS records
+- Solver configuration mismatches
+- ACME rate limits (use staging environment)


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Normalized PostgreSQL SSL across all dependency modes and overhauled the docs to be clearer, shorter, and action-focused. Managed providers now use TLS by default, and connection strings reflect the selected ssl_mode.

- **New Features**
  - Enforce TLS on AWS RDS (`rds.force_ssl = 1`); Azure/GCP default to `ssl_mode = require`; k8s respects `enable_ssl`; BYO supports `ssl_mode` (default `disable`).
  - Expose `ssl_mode` in outputs and use it in connection strings (`?sslmode=${...}`) for consistency across providers.
  - Helm values now merge SSL settings in `btp/main.tf` (ssl, sslMode, sslRejectUnauthorized=false) to work with managed certificates.

- **Refactors**
  - Rewrote documentation with simpler language, better navigation, and step-by-step commands across Getting Started, Configuration, Providers, Architecture, Operations, Security, and Troubleshooting.
  - Updated Terraform providers: bump azurerm to 4.49.0 and add hashicorp/http 3.5.0.

<!-- End of auto-generated description by cubic. -->

